### PR TITLE
Add SMTP4Dev dotnet global tool

### DIFF
--- a/src/smtp4dev/devcontainer-feature.json
+++ b/src/smtp4dev/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
     "name": "SMTP4Dev: A dotnet test email SMTP server",
     "id": "smtp4dev",
-    "version": "1.0.0",
+    "version": "0.1.0",
     "description": "Installs SMTP4Dev using 'dotnet tool install' into the devcontainer and maps the port",
     "keywords": [
         "smtp4dev",

--- a/src/smtp4dev/devcontainer-feature.json
+++ b/src/smtp4dev/devcontainer-feature.json
@@ -1,13 +1,12 @@
 {
-    "name": "SMTP4Dev",
+    "name": "SMTP4Dev: A dotnet test email SMTP server",
     "id": "smtp4dev",
     "version": "1.0.0",
     "description": "Installs SMTP4Dev using 'dotnet tool install' into the devcontainer and maps the port",
     "keywords": [
         "smtp4dev",
-        "SMTP",
-        "Email",
-        "Test SMTP"
+        "smtp",
+        "email"
     ],
     "options":{
         "webport": {
@@ -15,17 +14,23 @@
             "type": "string",
             "proposals": ["5000"],
             "default": "5000"
+        },
+        "smtpport": {
+            "description": "Port number for SMTP4Dev SMTP port to listen on",
+            "type": "string",
+            "proposals": ["2525"],
+            "default": "2525"
+        },
+        "imapport": {
+            "description": "Port number for SMTP4Dev IMAP port to listen on",
+            "type": "string",
+            "proposals": ["1443"],
+            "default": "1443"
         }
     },
-    }
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "alexcvzz.vscode-sqlite"
-            ]
-        }
-    },
+    "entrypoint": "entrypoint.sh",
     "installsAfter": [
-        "ghcr.io/devcontainers/features/common-utils"
+        "ghcr.io/devcontainers/features/common-utils",
+        "ghcr.io/devcontainers/features/dotnet"
     ]
 }

--- a/src/smtp4dev/devcontainer-feature.json
+++ b/src/smtp4dev/devcontainer-feature.json
@@ -1,0 +1,31 @@
+{
+    "name": "SMTP4Dev",
+    "id": "smtp4dev",
+    "version": "1.0.0",
+    "description": "Installs SMTP4Dev using 'dotnet tool install' into the devcontainer and maps the port",
+    "keywords": [
+        "smtp4dev",
+        "SMTP",
+        "Email",
+        "Test SMTP"
+    ],
+    "options":{
+        "webport": {
+            "description": "Port number for SMTP4Dev web UI",
+            "type": "string",
+            "proposals": ["5000"],
+            "default": "5000"
+        }
+    },
+    }
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "alexcvzz.vscode-sqlite"
+            ]
+        }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/common-utils"
+    ]
+}

--- a/src/smtp4dev/entrypoint.sh
+++ b/src/smtp4dev/entrypoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Attempt to start SMTP4Dev dotnet globnal tool
+set +e 
+
+################################################################################
+# Options/variables from configuring the feature - each with the a fallback value if not set
+SMTP4DEV_WEBPORT=${WEBPORT:-"5000"}
+SMTP4DEV_SMTPPORT=${SMTPPORT:-"2525"}
+SMTP4DEV_IMAPPORT=${IMAPPORT:-"1443"}
+
+################################################################################
+echo "SMTP4DEV:  Web Port: $SMTP4DEV_WEBPORT"
+echo "SMTP4DEV: SMTP Port: $SMTP4DEV_SMTPPORT"
+echo "SMTP4DEV: IMAP Port: $SMTP4DEV_IMAPPORT"
+
+################################################################################
+echo "Run SMTP4Dev global tool"
+smtp4dev --smtpport=2525 --imapport=1444

--- a/src/smtp4dev/install.sh
+++ b/src/smtp4dev/install.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+# Set –e is used within Bash to stop execution instantly 
+# as a query exits while having a non-zero status. 
+# This function is also used when you need to know 
+# the error location in the running code
+set -e
+
+echo "Activating SMTP4Dev feature"
+
+echo "Verifying dotnet is available"
+dotnet --version
+
+echo "Installing SMTP4Dev as a dotnet global tool"
+dotnet tool install -g Rnwood.Smtp4dev
+
+echo "Run SMTP4Dev global tool"
+smtp4dev
+#cd $HOME/.dotnet/tools && ./smtp4dev

--- a/src/smtp4dev/install.sh
+++ b/src/smtp4dev/install.sh
@@ -6,14 +6,28 @@
 # the error location in the running code
 set -e
 
+################################################################################
 echo "Activating SMTP4Dev feature"
 
+################################################################################
 echo "Verifying dotnet is available"
-dotnet --version
+if ! type dotnet2 >/dev/null 2>&1; then
+  echo "ERROR: Use a base image with dotnet installed or add the feature to devcontainer.json as 'dotnet tool install' is needed
 
+    "features": {
+        "ghcr.io/devcontainers/features/dotnet:1": {}
+    }
+  "
+  exit 1
+fi
+
+################################################################################
 echo "Installing SMTP4Dev as a dotnet global tool"
 dotnet tool install -g Rnwood.Smtp4dev
 
-echo "Run SMTP4Dev global tool"
-smtp4dev
-#cd $HOME/.dotnet/tools && ./smtp4dev
+################################################################################
+echo "Add dotnet tools to PATH"
+cat << \EOF >> ~/.bash_profile
+# Add .NET Core SDK tools
+export PATH="$PATH:/root/.dotnet/tools"
+EOF

--- a/test/smtp4dev/test.sh
+++ b/test/smtp4dev/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# This test file will be executed against an auto-generated devcontainer.json that
+# includes the 'sqlite' feature with no options.
+#
+# Eg:
+# {
+#    "image": "<..some-base-image...>",
+#    "features": {
+#      "smtp4dev": {}
+#    }
+# }
+# 
+# This test can be run with the following command (from the root of this repo)
+#    devcontainer features test --features smtp4dev
+#    devcontainer features test --features smtp4dev --base-image mcr.microsoft.com/devcontainers/dotnet:0-7.0
+
+set -e
+
+# Optional: Import test library bundled with the devcontainer CLI
+source dev-container-features-test-lib
+
+# Feature-specific tests
+# The 'check' command comes from the dev-container-features-test-lib.
+
+# Definition specific tests
+check "smtp4dev installed" type smtp4dev
+
+# Report result
+# If any of the checks above exited with a non-zero exit code, the test will fail.
+reportResults


### PR DESCRIPTION
This will allow the SMTP4Dev dotnet global tool to be installed with the following command
`dotnet tool install -g Rnwood.Smtp4dev`

Before running the dotnet tool command - the install bash script will check dotnet is installed.